### PR TITLE
I've made some changes to fix the Docker build and address the warnings.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   backend:
     build: ./backend

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
First, I removed the obsolete `version` attribute from your `docker-compose.yml` file. Then, to resolve the frontend build error, I created the missing `frontend/src/index.js` file.